### PR TITLE
Specify the cassandra version we want to install.

### DIFF
--- a/cassandra-base/Dockerfile
+++ b/cassandra-base/Dockerfile
@@ -17,9 +17,10 @@ RUN echo "deb http://debian.datastax.com/community stable main" > /etc/apt/sourc
 # Workaround for https://github.com/docker/docker/issues/6345
 RUN ln -s -f /bin/true /usr/bin/chfn
 
-# Install Cassandra 2.0.9
-RUN apt-get update
-RUN apt-get install -y dsc20
+# Install Cassandra 2.0.10
+RUN apt-get update && \
+    apt-get install -y cassandra=2.0.10 dsc20=2.0.10-1 && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV CASSANDRA_CONFIG /etc/cassandra
 


### PR DESCRIPTION
It wouldn't build otherwise now that the newest package of
cassandra and dsc disagree.
