### PR TITLE
Allow to override the cassandra DC.

### DIFF
--- a/cassandra/scripts/cassandra-singlenode.sh
+++ b/cassandra/scripts/cassandra-singlenode.sh
@@ -24,4 +24,10 @@ echo "JVM_OPTS=\"\$JVM_OPTS -Dcassandra.skip_wait_for_gossip_to_settle=0\"" >> $
 # Most likely not needed
 echo "JVM_OPTS=\"\$JVM_OPTS -Djava.rmi.server.hostname=$IP\"" >> $CASSANDRA_CONFIG/cassandra-env.sh
 
+# If configured in $CASSANDRA_DC, set the cassandra datacenter.
+if [ ! -z "$CASSANDRA_DC" ]; then
+    sed -i -e "s/endpoint_snitch: SimpleSnitch/endpoint_snitch: PropertyFileSnitch/" $CASSANDRA_CONFIG/cassandra.yaml
+    echo "default=$CASSANDRA_DC:rac1" > $CASSANDRA_CONFIG/cassandra-topology.properties
+fi
+
 cassandra -f


### PR DESCRIPTION
This is handy if you want to test with a datacenter-aware cassandra driver.
