### PR TITLE
Fix to return only 1 IP address

### DIFF
--- a/cassandra-cluster/scripts/cassandra-clusternode.sh
+++ b/cassandra-cluster/scripts/cassandra-clusternode.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
 # Get running container's IP
-IP=`hostname --ip-address`
-IP=`echo $IP | awk -F" " '{print $1}'`
+IP=`hostname --ip-address | cut -f 1 -d ' '`
 if [ $# == 1 ]; then SEEDS="$1,$IP"; 
 else SEEDS="$IP"; fi
 


### PR DESCRIPTION
If virtual IP is setup then `hostname --ip-address` returns 2 IP addresses and the docker container errors out
