### PR TITLE
Adding more explicit comment for JVM_OPTS

### DIFF
--- a/cassandra-cluster/scripts/cassandra-clusternode.sh
+++ b/cassandra-cluster/scripts/cassandra-clusternode.sh
@@ -34,6 +34,8 @@ fi
 echo "JVM_OPTS=\"\$JVM_OPTS -Dcassandra.initial_token=$CASSANDRA_TOKEN\"" >> $CASSANDRA_CONFIG/cassandra-env.sh
 
 # Most likely not needed
+# relates to the folllowing issue (nodetool remote connection issue):
+# http://www.datastax.com/documentation/cassandra/2.1/cassandra/troubleshooting/trblshootConnectionsFail_r.html
 echo "JVM_OPTS=\"\$JVM_OPTS -Djava.rmi.server.hostname=$IP\"" >> $CASSANDRA_CONFIG/cassandra-env.sh
 
 echo "Starting Cassandra on $IP..."


### PR DESCRIPTION
Giving the link of the possible issue for which 
JVM_OPTS -Djava.rmi.server.hostname
might or might not be needed.
(nodetool remote connection issue)