### PR TITLE
Launch cassandra with exec so it can respond to SIGTERM

### DIFF
--- a/cassandra-cluster/scripts/cassandra-clusternode.sh
+++ b/cassandra-cluster/scripts/cassandra-clusternode.sh
@@ -38,4 +38,4 @@ echo "JVM_OPTS=\"\$JVM_OPTS -Djava.rmi.server.hostname=$IP\"" >> $CASSANDRA_CONF
 
 echo "Starting Cassandra on $IP..."
 
-cassandra -f
+exec cassandra -f

--- a/cassandra/scripts/cassandra-singlenode.sh
+++ b/cassandra/scripts/cassandra-singlenode.sh
@@ -30,4 +30,4 @@ if [ ! -z "$CASSANDRA_DC" ]; then
     echo "default=$CASSANDRA_DC:rac1" > $CASSANDRA_CONFIG/cassandra-topology.properties
 fi
 
-cassandra -f
+exec cassandra -f


### PR DESCRIPTION
The entrypoint for our containers is a bash startup script. When you stop
the container, SIGTERM is sent to the script and not the cassandra process.
Cassandra would shut down gracefully if it received the signal, but it does not,
so we have to wait for the operation to timeout and then docker will kill the
container. This change launches the containers with 'exec' so that the
cassandra process becomes pid 1, and therefore receives the signals, and shuts
down immediately.