### PR TITLE
Give the option to configure the broadcast for multi-node cluster setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ In the box
 
   Runs a Cassandra cluster. Expects `CASSANDRA_SEEDS` and `CASSANDRA_TOKEN` env variables to be set.
   If `CASSANDRA_SEEDS` is not set, node acts as its own seed. If `CASSANDRA_TOKEN` is not set, the
-  container will not run. Built from the `cassandra-cluster` directory.
+  container will not run. Built from the `cassandra-cluster` directory. If `CASSANDRA_BROADCAST_ADDRESS`
+  is set use this address for external communication with other cassandra nodes (typical use case:
+  multi-node docker setup) 
 
 * **spotify/cassandra:base**
 

--- a/cassandra-cluster/scripts/cassandra-clusternode.sh
+++ b/cassandra-cluster/scripts/cassandra-clusternode.sh
@@ -2,8 +2,15 @@
 
 # Get running container's IP
 IP=`hostname --ip-address | cut -f 1 -d ' '`
-if [ $# == 1 ]; then SEEDS="$1,$IP"; 
-else SEEDS="$IP"; fi
+# If broadcast address is set, use this address as the external IP (for broadcast and seed)
+if [ -z "$CASSANDRA_BROADCAST_ADDRESS" ] ; then
+	EIP=$IP
+else
+	EIP=$CASSANDRA_BROADCAST_ADDRESS
+fi
+
+if [ $# == 1 ]; then SEEDS="$1,$EIP"; 
+else SEEDS="$EIP"; fi
 
 # Setup cluster name
 if [ -z "$CASSANDRA_CLUSTERNAME" ]; then
@@ -14,10 +21,13 @@ fi
 
 
 # Dunno why zeroes here
-sed -i -e "s/^rpc_address.*/rpc_address: $IP/" $CASSANDRA_CONFIG/cassandra.yaml
+sed -i -e "s/^rpc_address.*/rpc_address: 0.0.0.0/" $CASSANDRA_CONFIG/cassandra.yaml
 
 # Listen on IP:port of the container
 sed -i -e "s/^listen_address.*/listen_address: $IP/" $CASSANDRA_CONFIG/cassandra.yaml
+
+# Listen on IP:port of the container
+sed -i -e "s/^#\? *broadcast_address.*/broadcast_address: $EIP/" $CASSANDRA_CONFIG/cassandra.yaml
 
 # Configure Cassandra seeds
 if [ -z "$CASSANDRA_SEEDS" ]; then

--- a/cassandra-cluster/scripts/cassandra-clusternode.sh
+++ b/cassandra-cluster/scripts/cassandra-clusternode.sh
@@ -44,8 +44,8 @@ fi
 echo "JVM_OPTS=\"\$JVM_OPTS -Dcassandra.initial_token=$CASSANDRA_TOKEN\"" >> $CASSANDRA_CONFIG/cassandra-env.sh
 
 # Most likely not needed
-echo "JVM_OPTS=\"\$JVM_OPTS -Djava.rmi.server.hostname=$IP\"" >> $CASSANDRA_CONFIG/cassandra-env.sh
+echo "JVM_OPTS=\"\$JVM_OPTS -Djava.rmi.server.hostname=$EIP\"" >> $CASSANDRA_CONFIG/cassandra-env.sh
 
-echo "Starting Cassandra on $IP..."
+echo "Starting Cassandra on $EIP..."
 
 exec cassandra -f


### PR DESCRIPTION
When setting up a multi-nodes cassandra cluster, it was necessary to use the --net=host option of docker
This PR allows the configuration of the broadcast-address parameter which removes this necessity
